### PR TITLE
Use the general download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Based on and inspired by https://github.com/petehunt/react-howto
 ## Contributing
 
 1. Edit the `.dot` file with https://atom.io/packages/graphviz-preview
-2. Install `dot` from http://www.graphviz.org/Download_macos.php (other versions are on the website too)
+2. Install `dot` from http://www.graphviz.org/Download.php 
 3. Generate the `.svg` with `dot -Tsvg fatigue.dot > fatigue.svg`
 4. Send a PR!
 


### PR DESCRIPTION
Although the original reference indicates other platforms are
supported, why not just link there initially? It seems friendlier.
